### PR TITLE
"prop-types" dependency and new linter rules added

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,11 @@
 module.exports = {
   // extends: ['@mate-academy/eslint-config-react-typescript', 'plugin:cypress/recommended'],
   extends: ['@mate-academy/eslint-config-react', 'plugin:cypress/recommended'],
+  rules: {
+    'import/no-extraneous-dependencies': ['error', {
+      devDependencies: false,
+      optionalDependencies: false,
+      peerDependencies: false,
+    }],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/node": "^12.20.18",
     "@types/react": "^17.0.15",
     "@types/react-dom": "^17.0.9",
+    "prop-types": "^15.7.2",
     "node-sass": "^6.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
There was a problem with compiling in react task ('prop-types' should be listed in the project's dependencies. Run 'npm i -S prop-types' to add it, installation of 'prop-types' didn't help)

In this PR was added linter rules that helped to fix this problem

Dependency "prop-types" was added to package.json too